### PR TITLE
Rename tasks column

### DIFF
--- a/lib/to_do/tasks/task.ex
+++ b/lib/to_do/tasks/task.ex
@@ -9,7 +9,7 @@ defmodule ToDo.Tasks.Task do
           id: nil | Ecto.UUID.t(),
           title: nil | String.t(),
           description: nil | String.t(),
-          is_done?: boolean()
+          is_completed?: boolean()
         }
 
   @primary_key {:id, :binary_id, autogenerate: true}
@@ -17,7 +17,7 @@ defmodule ToDo.Tasks.Task do
   schema "tasks" do
     field(:title, :string)
     field(:description, :string)
-    field(:is_done?, :boolean, default: false)
+    field(:is_completed?, :boolean, default: false)
 
     timestamps()
   end

--- a/priv/repo/migrations/20240120213345_rename_tasks_table_is_done_column.exs
+++ b/priv/repo/migrations/20240120213345_rename_tasks_table_is_done_column.exs
@@ -1,0 +1,7 @@
+defmodule ToDo.Repo.Migrations.RenameTasksTableIsDoneColumn do
+  use Ecto.Migration
+
+  def change do
+    rename table(:tasks, :is_done?, to: :is_completed?)
+  end
+end


### PR DESCRIPTION
### Why is this pull request necessary?
Was decided to rename the tasks column is_done? to is_completed?

### What changes does this pull request add?
- Add migration to rename tasks column
- Update tasks schema
